### PR TITLE
Add Ask Difficulty

### DIFF
--- a/drizzle/0004_rainy_alex_wilder.sql
+++ b/drizzle/0004_rainy_alex_wilder.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "givetogive_ask" ADD COLUMN "difficulty" integer DEFAULT 1 NOT NULL;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,443 @@
+{
+  "id": "743af242-ba19-45f9-9f76-244b43428e32",
+  "prevId": "62d58e57-a3e2-4a2d-b7e5-635e58114666",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.givetogive_account": {
+      "name": "givetogive_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "givetogive_account_user_id_givetogive_user_id_fk": {
+          "name": "givetogive_account_user_id_givetogive_user_id_fk",
+          "tableFrom": "givetogive_account",
+          "tableTo": "givetogive_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "givetogive_account_provider_provider_account_id_pk": {
+          "name": "givetogive_account_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.givetogive_ask": {
+      "name": "givetogive_ask",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "estimated_minutes_to_complete": {
+          "name": "estimated_minutes_to_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfilled_by": {
+          "name": "fulfilled_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ask_created_by_idx": {
+          "name": "ask_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asks_slug_idx": {
+          "name": "asks_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ask_title_idx": {
+          "name": "ask_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "givetogive_ask_created_by_givetogive_user_id_fk": {
+          "name": "givetogive_ask_created_by_givetogive_user_id_fk",
+          "tableFrom": "givetogive_ask",
+          "tableTo": "givetogive_user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "givetogive_ask_fulfilled_by_givetogive_user_id_fk": {
+          "name": "givetogive_ask_fulfilled_by_givetogive_user_id_fk",
+          "tableFrom": "givetogive_ask",
+          "tableTo": "givetogive_user",
+          "columnsFrom": [
+            "fulfilled_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "givetogive_ask_slug_unique": {
+          "name": "givetogive_ask_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.givetogive_session": {
+      "name": "givetogive_session",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "givetogive_session_user_id_givetogive_user_id_fk": {
+          "name": "givetogive_session_user_id_givetogive_user_id_fk",
+          "tableFrom": "givetogive_session",
+          "tableTo": "givetogive_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.givetogive_user": {
+      "name": "givetogive_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.givetogive_verification_token": {
+      "name": "givetogive_verification_token",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "givetogive_verification_token_identifier_token_pk": {
+          "name": "givetogive_verification_token_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1729997030579,
       "tag": "0003_overrated_piledriver",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1752541403080,
+      "tag": "0004_rainy_alex_wilder",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/asks/_components/ClientFormFields.tsx
+++ b/src/app/asks/_components/ClientFormFields.tsx
@@ -3,7 +3,13 @@
 import { varNameToHumanReadable } from '@/lib/utils/string-formatting';
 import type { AppRouter } from '@/server/api/root';
 import { api } from '@/trpc/react';
-import { Button, TextField } from '@mui/material';
+import {
+	Button,
+	FormHelperText,
+	Slider,
+	TextField,
+	Typography,
+} from '@mui/material';
 import { useForm } from '@tanstack/react-form';
 import { zodValidator } from '@tanstack/zod-form-adapter';
 import type { inferRouterInputs } from '@trpc/server';
@@ -22,9 +28,12 @@ export function ClientFormFields({ onCancel }: ClientFormFieldsProps) {
 
 	// Extract default values from URL parameters
 	const estimatedMinutes = searchParams.get('estimatedMinutesToComplete');
+	const difficultyParam = searchParams.get('difficulty');
 	const defaultValues: FormValues = {
 		title: searchParams.get('title') ?? '',
 		description: searchParams.get('description') ?? '',
+		difficulty:
+			typeof difficultyParam === 'string' ? parseInt(difficultyParam) : 1,
 		estimatedMinutesToComplete:
 			typeof estimatedMinutes === 'string' ?
 				parseInt(estimatedMinutes)
@@ -58,6 +67,7 @@ export function ClientFormFields({ onCancel }: ClientFormFieldsProps) {
 						message: 'The title cannot solely consist of numbers',
 					}),
 				description: z.string().min(10),
+				difficulty: z.number().int().min(1).max(5),
 				estimatedMinutesToComplete: z.number().int().min(1),
 			}),
 		},
@@ -76,11 +86,12 @@ export function ClientFormFields({ onCancel }: ClientFormFieldsProps) {
 		},
 	});
 
-	// Helper function to serialize form values into URL parameters
 	function serializeFormValues(values: FormValues) {
+		// Helper function to serialize form values into URL parameters
 		const params = new URLSearchParams();
 		params.set('title', values.title);
 		params.set('description', values.description);
+		params.set('difficulty', values.difficulty.toString());
 		params.set(
 			'estimatedMinutesToComplete',
 			values.estimatedMinutesToComplete.toString(),
@@ -165,6 +176,38 @@ export function ClientFormFields({ onCancel }: ClientFormFieldsProps) {
 						fullWidth
 						margin='normal'
 					/>
+				)}
+			/>
+			<Field
+				name='difficulty'
+				children={({
+					name,
+					state: {
+						value,
+						meta: { errors, isTouched },
+					},
+					handleChange,
+				}) => (
+					<>
+						<Typography gutterBottom>
+							{varNameToHumanReadable(name)}
+						</Typography>
+						<Slider
+							value={value}
+							onChange={(_, newValue) =>
+								handleChange(newValue as number)
+							}
+							min={1}
+							max={5}
+							step={1}
+							valueLabelDisplay='auto'
+						/>
+						{isTouched && errors.length > 0 && (
+							<FormHelperText error>
+								{errors.join(', ')}
+							</FormHelperText>
+						)}
+					</>
 				)}
 			/>
 			<Button

--- a/src/server/api/routers/ask.ts
+++ b/src/server/api/routers/ask.ts
@@ -14,13 +14,14 @@ export const askRouter = createTRPCRouter({
 			insertAskSchema.pick({
 				title: true,
 				description: true,
+				difficulty: true,
 				estimatedMinutesToComplete: true,
 			}),
 		)
 		.mutation(
 			async ({
 				ctx,
-				input: { title, description, estimatedMinutesToComplete },
+				input: { title, description, difficulty, estimatedMinutesToComplete },
 			}) => {
 				const newlyCreatedSlug = title
 					.toLowerCase()
@@ -31,6 +32,7 @@ export const askRouter = createTRPCRouter({
 						title,
 						slug: newlyCreatedSlug,
 						description,
+						difficulty,
 						estimatedMinutesToComplete,
 						status: 'not_started',
 						createdById: ctx.session.user.id,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -22,10 +22,11 @@ export const asks = createTable(
 		id: serial('id').primaryKey(),
 		slug: varchar('slug', { length: 256 }).notNull().unique(),
 		title: varchar('title', { length: 256 }).notNull(),
-		description: text('description').notNull(),
-		estimatedMinutesToComplete: integer(
-			'estimated_minutes_to_complete',
-		).notNull(),
+	description: text('description').notNull(),
+	difficulty: integer('difficulty').notNull().default(1),
+	estimatedMinutesToComplete: integer(
+		'estimated_minutes_to_complete',
+	).notNull(),
 		status: varchar('status', { length: 50 })
 			.notNull()
 			.$type<'not_started' | 'in_progress' | 'complete'>()
@@ -57,6 +58,11 @@ export const insertAskSchema = createInsertSchema(asks, {
 			10,
 			'Description must be at least 10 characters long',
 		),
+	difficulty: (schema) =>
+		schema.difficulty
+			.int()
+			.min(1, 'Difficulty must be at least 1')
+			.max(5, 'Difficulty must be at most 5'),
 	estimatedMinutesToComplete: (schema) =>
 		schema.estimatedMinutesToComplete
 			.int()


### PR DESCRIPTION
This PR adds a new field for difficulty in the ask form, allowing users to specify the difficulty level of their asks. The field is optional and can be left blank if not applicable. The changes include updates to the form validation and serialization logic.